### PR TITLE
Misc updates

### DIFF
--- a/message.go
+++ b/message.go
@@ -28,27 +28,30 @@ type MessageType uint8
 const (
 	// MessageTypeOK indicates that requested operation was successful.
 	// The payload is empty.
-	MessageTypeOK MessageType = iota
+	MessageTypeOK MessageType = 0x01
 
 	// MessageTypeError indicates that requested operation failed.
 	// The payload contains the error message.
-	MessageTypeError
+	MessageTypeError MessageType = 0x02
+
+	// MessageTypeGoAway indicates that client should reconnect to another server.
+	MessageTypeGoAway MessageType = 0x03
 
 	// MessageTypeTCPTunnel indicates that the message is a TCP tunnel request.
 	// The payload contains the remote host and port.
-	MessageTypeTCPTunnel
+	MessageTypeTCPTunnel MessageType = 0x10
 
 	// MessageTypeUDPTunnel indicates that the message is a UDP tunnel request.
 	// The payload contains the suggested listener port, remote host and port.
-	MessageTypeUDPTunnel
+	MessageTypeUDPTunnel MessageType = 0x11
 
 	// MessageTypePTY indicates that the message is a PTY request.
 	// The payload contains initial JSON-encoded PTYCommand with PTYCommandTypeResize to set the initial window size.
-	MessageTypePTY
+	MessageTypePTY MessageType = 0x12
 
 	// MessageTypePTYCommand indicates that the message is a PTY command request.
 	// The payload contains JSON-encoded PTYCommand.
-	MessageTypePTYCommand
+	MessageTypePTYCommand MessageType = 0x13
 )
 
 // Message wire format:

--- a/pty.go
+++ b/pty.go
@@ -26,11 +26,11 @@ const (
 
 // PTYCommand carries a command to be executed on the PTY stream.
 type PTYCommand struct {
+	// SessionID is the session ID (initiated with MessageTypePTY) to which the command applies.
+	SessionID string `json:"sid"`
+
 	// Type is the type of the command to be executed on the PTY.
 	Type PTYCommandType `json:"type,omitempty"`
-
-	// StreamID is the ID of the stream (initiated with MessageTypePTY) to which the command applies.
-	StreamID uint32 `json:"sid"`
 
 	// Cols and Rows are the new window size.
 	// Those fields are only used when Type is PTYCommandTypeResize.

--- a/udp_tunnel.go
+++ b/udp_tunnel.go
@@ -395,12 +395,14 @@ func (t *UDPTunnel) getOrCreateStream(cliAddr *net.UDPAddr, listener *net.UDPCon
 }
 
 // Close closes the tunnel.
-func (t *UDPTunnel) Close() {
-	_ = t.localListener.Close()
+func (t *UDPTunnel) Close() error {
+	err := t.localListener.Close()
 
 	for _, stream := range t.streams {
 		stream.close()
 	}
+
+	return err
 }
 
 // newDeviceUDPListener creates a new UDP listener for the given destination address.

--- a/udp_tunnel_test.go
+++ b/udp_tunnel_test.go
@@ -122,7 +122,7 @@ func Test_UDPTunnel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(udpTunnel.Close)
+	t.Cleanup(func() { _ = udpTunnel.Close() })
 
 	t.Log("cli: initializing listener")
 	var clientListener *net.UDPConn


### PR DESCRIPTION
- Implement io.Closer for UDPTunnel to match TCP listener,
- Use hard coded message types and add go-away message,
- Implement basic go-away support for the device client,
- Switch to session IDs for PTY messages.