### PR TITLE
Monthly patching - July 2025

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,15 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.22.12
+          go-version: 1.24.5
           cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.64.5
-          only-new-issues: true
-          skip-cache: true
-          skip-pkg-cache: true
-          skip-build-cache: true
+          version: v2.1

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.22.12
+          go-version: 1.24.5
 
       - name: go test
         run: go test ./...
@@ -22,7 +22,7 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.22.12
+          go-version-input: 1.24.5
           go-package: ./...
 
       - name: golint

--- a/client.go
+++ b/client.go
@@ -129,7 +129,7 @@ func (cli *Client) OpenTCPTunnel(ctx context.Context, localHostPort, remoteHostP
 			}
 
 			go func() {
-				defer tcpConnection.Close()
+				defer func() { _ = tcpConnection.Close() }()
 
 				if connErr := cli.newTCPConnection(ctx, tcpConnection, remoteHostPort); connErr != nil {
 					log.Printf("error forwarding TCP connection: %v", connErr)

--- a/device_client.go
+++ b/device_client.go
@@ -90,7 +90,7 @@ func (cli *DeviceClient) startOnce(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer smuxSession.Close()
+	defer func() { _ = smuxSession.Close() }()
 
 	// mark client as ready and defer the removal of the ready marker
 	cli.ready.Done()
@@ -191,8 +191,10 @@ var deviceDialer = net.Dialer{}
 // handleStream handles a new stream and log any errors.
 func (cli *DeviceClient) handleStream(ctx context.Context, stream *smux.Stream) {
 	// ensure the stream is always closed
-	defer stream.Close()
-	defer cli.streamWg.Done()
+	defer func() {
+		_ = stream.Close()
+		cli.streamWg.Done()
+	}()
 
 	// each stream starts with a message defining the type of tunnel
 	messageType, payload, err := ReadMessage(stream)

--- a/edge_mock.go
+++ b/edge_mock.go
@@ -61,7 +61,7 @@ func (edge *EdgeMock) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		return
 	}
-	defer smuxSession.Close()
+	defer func() { _ = smuxSession.Close() }()
 
 	if isDevice {
 		edge.device = smuxSession

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module go.qbee.io/transport
 
 go 1.21
 
-require github.com/xtaci/smux v1.5.24
+require github.com/xtaci/smux v1.5.34

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module go.qbee.io/transport
 
-go 1.22
+go 1.24
 
 require github.com/xtaci/smux v1.5.34

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/xtaci/smux v1.5.24 h1:77emW9dtnOxxOQ5ltR+8BbsX1kzcOxQ5gB+aaV9hXOY=
-github.com/xtaci/smux v1.5.24/go.mod h1:OMlQbT5vcgl2gb49mFkYo6SMf+zP3rcjcwQz7ZU7IGY=
+github.com/xtaci/smux v1.5.34 h1:OUA9JaDFHJDT8ZT3ebwLWPAgEfE6sWo2LaTy3anXqwg=
+github.com/xtaci/smux v1.5.34/go.mod h1:OMlQbT5vcgl2gb49mFkYo6SMf+zP3rcjcwQz7ZU7IGY=

--- a/protocol.go
+++ b/protocol.go
@@ -32,18 +32,18 @@ import (
 // We use a timeout to avoid blocking the tunnel indefinitely.
 const ioWaitTimeout = 15 * time.Second
 
-var udpIOWaitTimeoutCtxKey = struct{}{}
+type udpIOWaitTimeoutCtxKey struct{}
 
 // WithIOWaitTimeout returns a copy of the context with the specified timeout for I/O operations.
 func WithIOWaitTimeout(ctx context.Context, timeout time.Duration) context.Context {
-	return context.WithValue(ctx, udpIOWaitTimeoutCtxKey, timeout)
+	return context.WithValue(ctx, udpIOWaitTimeoutCtxKey{}, timeout)
 }
 
 // getIOWaitTimeout returns the timeout for I/O operations.
 // If the context contains a timeout, that timeout will be returned.
 // Otherwise, the default timeout will be returned.
 func getIOWaitTimeout(ctx context.Context) time.Duration {
-	if timeout, ok := ctx.Value(udpIOWaitTimeoutCtxKey).(time.Duration); ok {
+	if timeout, ok := ctx.Value(udpIOWaitTimeoutCtxKey{}).(time.Duration); ok {
 		return timeout
 	}
 

--- a/tcp_tunnel.go
+++ b/tcp_tunnel.go
@@ -29,7 +29,7 @@ func (cli *Client) newTCPConnection(ctx context.Context, conn *net.TCPConn, remo
 	if err != nil {
 		return err
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }()
 
 	_, _, err = Pipe(conn, stream)
 
@@ -42,7 +42,7 @@ func HandleTCPTunnel(ctx context.Context, stream *smux.Stream, remoteAddr []byte
 	if err != nil {
 		return WriteError(stream, err)
 	}
-	defer tcpConn.Close()
+	defer func() { _ = tcpConn.Close() }()
 
 	if err = WriteOK(stream, nil); err != nil {
 		return err

--- a/tcp_tunnel_test.go
+++ b/tcp_tunnel_test.go
@@ -49,7 +49,7 @@ func Test_TCPTunnel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error opening TCP tunnel: %v", err)
 	}
-	defer localListener.Close()
+	t.Cleanup(func() { _ = localListener.Close() })
 
 	testURL := "http://" + localListener.Addr().String()
 
@@ -90,13 +90,13 @@ func BenchmarkTCPTunnel(b *testing.B) {
 	if err != nil {
 		b.Fatalf("error opening remote listener: %v", err)
 	}
-	defer remoteListener.Close()
+	b.Cleanup(func() { _ = remoteListener.Close() })
 
 	var localListener net.Listener
 	if localListener, err = client.OpenTCPTunnel(ctx, "localhost:0", remoteListener.Addr().String()); err != nil {
 		b.Fatalf("error opening TCP tunnel: %v", err)
 	}
-	defer localListener.Close()
+	b.Cleanup(func() { _ = localListener.Close() })
 
 	var localConn, remoteConn net.Conn
 
@@ -108,12 +108,12 @@ func BenchmarkTCPTunnel(b *testing.B) {
 	if remoteConn, err = remoteListener.Accept(); err != nil {
 		b.Fatalf("error accepting remote connection: %v", err)
 	}
-	defer remoteConn.Close()
+	b.Cleanup(func() { _ = remoteConn.Close() })
 
 	if localConnErr != nil {
 		b.Fatalf("error opening local connection: %v", err)
 	}
-	defer localConn.Close()
+	b.Cleanup(func() { _ = localConn.Close() })
 
 	const bufSize = 128 * 1024
 	buf := make([]byte, bufSize)

--- a/udp_tunnel.go
+++ b/udp_tunnel.go
@@ -554,7 +554,7 @@ func HandleUDPTunnel(ctx context.Context, stream *smux.Stream, payload []byte) e
 	if udpListener, err = newDeviceUDPListener(dstAddr, suggestedSrcPort); err != nil {
 		return WriteError(stream, err)
 	}
-	defer udpListener.Close()
+	defer func() { _ = udpListener.Close() }()
 
 	if err = WriteOK(stream, nil); err != nil {
 		return err


### PR DESCRIPTION
This pull request includes updates to dependencies, improvements to resource cleanup practices, and a minor refactor for context key handling. The most important changes ensure compatibility with newer versions of Go and related tools, enhance code reliability by addressing potential issues during resource cleanup, and improve type safety in context key usage.

### Dependency Updates:
* [`.github/workflows/golangci-lint.yml`](diffhunk://#diff-d9a956120ac84289d2650137f64bd8f0893331de05e44cc41899dd984c9e0d48L19-R26): Updated `setup-go` action to version 5, Go version to 1.24.5, and `golangci-lint-action` to version 8, along with its linting tool version to v2.1.
* [`.github/workflows/pr-test.yml`](diffhunk://#diff-cf34a98fd25d1698b625c9a988868d4cef5036692a76d1e28dc5aa42be237b9eL15-R25): Updated `setup-go` action to version 5 and Go version to 1.24.5 for consistency across workflows.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Upgraded Go module version from 1.22 to 1.24.

### Resource Cleanup Improvements:
* `client.go`, `device_client.go`, `tcp_tunnel.go`, `edge_mock.go`, `udp_tunnel.go`: Replaced direct `Close()` calls with `defer` statements wrapped in anonymous functions to safely handle errors during resource cleanup. [[1]](diffhunk://#diff-4b667feae66c9d46b21b9ecc19e8958cf4472d162ce0a47ac3e8386af8bbd8cfL132-R132) [[2]](diffhunk://#diff-c6e059bddcc1cc299d35395dc021fdce1a4037d0944eb96e95eb057704c91dafL93-R93) [[3]](diffhunk://#diff-c6e059bddcc1cc299d35395dc021fdce1a4037d0944eb96e95eb057704c91dafL194-R197) [[4]](diffhunk://#diff-315fc457837a13ea9b2518053b9e69976e840ba6fdc359f198515b6694bb953eL64-R64) [[5]](diffhunk://#diff-79e6ef2b5520d8559637ee1f84578a96d850c427ef868c2213fda4f00950fa3dL32-R32) [[6]](diffhunk://#diff-79e6ef2b5520d8559637ee1f84578a96d850c427ef868c2213fda4f00950fa3dL45-R45) [[7]](diffhunk://#diff-25f2d6dc6876f78c692d26c3ed72fd4076126b55013d7a43896bc356a72f4b20L557-R557)
* [`tcp_tunnel_test.go`](diffhunk://#diff-731cad7c87d0060af368b29cdefb10cdc925ef9e0f9e6c6ffe43c413bb25b2deL52-R52): Refactored `defer` statements to use `t.Cleanup` and `b.Cleanup` for better test resource management. [[1]](diffhunk://#diff-731cad7c87d0060af368b29cdefb10cdc925ef9e0f9e6c6ffe43c413bb25b2deL52-R52) [[2]](diffhunk://#diff-731cad7c87d0060af368b29cdefb10cdc925ef9e0f9e6c6ffe43c413bb25b2deL93-R99) [[3]](diffhunk://#diff-731cad7c87d0060af368b29cdefb10cdc925ef9e0f9e6c6ffe43c413bb25b2deL111-R116)

### Context Key Refactor:
* [`protocol.go`](diffhunk://#diff-7a50e7dfed70deb86642d34ce85399fa54d3402304c3fd31157a4552a163ad38L35-R46): Changed `udpIOWaitTimeoutCtxKey` from a variable to a distinct `struct` type for improved type safety and reduced risk of key collisions in context usage.