### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/qbee-io/transport/security/code-scanning/1](https://github.com/qbee-io/transport/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly define the permissions required for the workflow, ensuring that the `GITHUB_TOKEN` has only the minimum privileges necessary. Based on the workflow's steps, the `contents: read` permission is sufficient, as the workflow does not perform any write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
