### PR TITLE
DEV-3004: Fix path traversal vulnerability in file download/upload functionality

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: 1.25.9
           cache: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
-          go-version: 1.26.2
+          go-version: 1.26
 
       - name: go test
         run: go test ./...
@@ -24,7 +24,7 @@ jobs:
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.26.2
+          go-version-input: 1.26
           go-package: ./...
 
       - name: golint

--- a/file_transfer.go
+++ b/file_transfer.go
@@ -476,7 +476,12 @@ func extractFile(tarReader *tar.Reader, targetPath string, header *tar.Header) e
 		return err
 	}
 
-	f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
+	// Always remove existing file/symlink at target path before creating new file to prevent abuse of hard links in the archive.
+	if err := os.Remove(targetPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("error removing existing entry %s: %w", targetPath, err)
+	}
+
+	f, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY|os.O_TRUNC, os.FileMode(header.Mode))
 	if err != nil {
 		return fmt.Errorf("error creating file %s: %w", targetPath, err)
 	}

--- a/file_transfer_test.go
+++ b/file_transfer_test.go
@@ -890,3 +890,119 @@ func TestValidateSymlink(t *testing.T) {
 		})
 	}
 }
+
+// TestExtractTar_SymlinkTraversalEscape reproduces a path-traversal vulnerability
+// in extractTar: validateSymlink and validatePath are purely lexical, but
+// extractFile opens regular files with O_CREATE|O_WRONLY|O_TRUNC and no
+// O_NOFOLLOW. A crafted tar containing
+//
+//  1. a self-referential symlink   "d"    -> "."
+//  2. a traversing symlink         "evil" -> "d/../pwn"
+//  3. a regular file               "evil" with attacker-controlled contents
+//
+// passes every lexical check (filepath.Clean strips "d/.." textually so the
+// resolved target appears to be inside destPath), but on disk the kernel
+// follows the planted "d" symlink in step 3 and the truncate/write lands in
+// the *parent* directory of destPath.
+func TestExtractTar_SymlinkTraversalEscape(t *testing.T) {
+	// Use a dedicated parent so we can detect a file written one level above
+	// the extraction destination. t.TempDir() cleans this whole tree up.
+	parent := t.TempDir()
+	destPath := filepath.Join(parent, "dest")
+	if err := os.Mkdir(destPath, 0o755); err != nil {
+		t.Fatalf("failed to create destPath: %v", err)
+	}
+
+	// Sentinel that must NOT be overwritten. It lives in the parent dir,
+	// i.e. one level above destPath – the exact location the attack aims for.
+	sentinelPath := filepath.Join(parent, "pwn")
+	const originalContent = "original-untouched"
+	if err := os.WriteFile(sentinelPath, []byte(originalContent), 0o600); err != nil {
+		t.Fatalf("failed to seed sentinel file: %v", err)
+	}
+
+	// Build the malicious tar in memory.
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	// 1. d -> "."  (self-reference; lexically resolves to destPath, allowed)
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeSymlink,
+		Name:     "d",
+		Linkname: ".",
+		Mode:     0o777,
+	}); err != nil {
+		t.Fatalf("write header d: %v", err)
+	}
+
+	// 2. evil -> "d/../pwn"
+	//    validateSymlink computes Clean(destPath + "/" + "d/../pwn") = destPath/pwn,
+	//    which lexically lives inside destPath, so the check passes.
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeSymlink,
+		Name:     "evil",
+		Linkname: "d/../pwn",
+		Mode:     0o777,
+	}); err != nil {
+		t.Fatalf("write header evil symlink: %v", err)
+	}
+
+	// 3. Regular file "evil". validatePath returns destPath/evil (allowed),
+	//    extractFile then OpenFile's it without O_NOFOLLOW, follows the planted
+	//    symlink, and the kernel resolves d/../pwn outside destPath.
+	pwned := []byte("PWNED-by-traversal")
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg,
+		Name:     "evil",
+		Mode:     0o644,
+		Size:     int64(len(pwned)),
+	}); err != nil {
+		t.Fatalf("write header evil regular: %v", err)
+	}
+	if _, err := tw.Write(pwned); err != nil {
+		t.Fatalf("write evil body: %v", err)
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+
+	// Drive the actual library entry point used on the device side.
+	tr := tar.NewReader(&buf)
+	if err := extractTar(tr, destPath); err != nil {
+		// An error here would actually be the *secure* outcome – the library
+		// should refuse the archive. We tolerate it and let the post-conditions
+		// below decide whether the attack succeeded.
+		t.Logf("extractTar returned error (acceptable if no escape occurred): %v", err)
+	}
+
+	// --- Post-conditions: the attack must NOT have escaped destPath. ---
+
+	// The sentinel file in the parent directory must still hold its original
+	// contents. If it now contains the attacker payload, the kernel followed
+	// the planted symlink and the write landed outside destPath.
+	got, err := os.ReadFile(sentinelPath)
+	if err != nil {
+		t.Fatalf("sentinel file unexpectedly missing: %v", err)
+	}
+	if string(got) != originalContent {
+		t.Fatalf(
+			"path traversal: file at %s (parent of destPath) was overwritten;\n"+
+				"  want %q\n  got  %q",
+			sentinelPath, originalContent, string(got),
+		)
+	}
+
+	// Nothing should ever have been created outside destPath as a side effect.
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		t.Fatalf("read parent dir: %v", err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name == "dest" || name == "pwn" {
+			continue
+		}
+		t.Errorf("unexpected entry created outside destPath: %s", name)
+	}
+}


### PR DESCRIPTION
This pull request addresses a security vulnerability in the tar extraction logic that could allow a crafted archive to overwrite files outside the intended extraction directory via symlink traversal. The changes both fix the vulnerability and add a regression test to ensure the issue does not recur.

**Security fix for tar extraction:**

* The `extractFile` function in `file_transfer.go` now always removes any existing file or symlink at the target path before creating a new file, and uses `os.O_EXCL` to prevent following symlinks/hardlinks during file creation. This mitigates a path traversal attack where a malicious tar could overwrite files outside the extraction directory.

**Testing and validation:**

* Adds a new test, `TestExtractTar_SymlinkTraversalEscape`, in `file_transfer_test.go` that reproduces the symlink traversal vulnerability and verifies that extraction does not overwrite files outside the intended directory. This test ensures that the fix is effective and guards against future regressions.

**Acknowledgment:**

The issue has been reported by @ttzero25 through our Vulnerability Disclosure program.