### PR TITLE
Remove symlink support from file transfer

### DIFF
--- a/file_transfer.go
+++ b/file_transfer.go
@@ -496,7 +496,7 @@ func mkdirAllRooted(root *os.Root, relPath string, mode os.FileMode) error {
 	}
 
 	var current string
-	for _, part := range filepath.SplitList(relPath) {
+	for part := range strings.SplitSeq(relPath, string(filepath.Separator)) {
 		if part == "" {
 			continue
 		}

--- a/file_transfer.go
+++ b/file_transfer.go
@@ -275,7 +275,7 @@ func handleUpload(stream *smux.Stream, destPath string) error {
 // For a single file, the archive contains one entry with the file's base name.
 // For a directory, the archive contains the directory and all its contents,
 // preserving the top-level directory name.
-// Symlinks are silently skipped.
+// Symlinks are silently skipped to avoid potential security issues.
 func archivePath(tarWriter *tar.Writer, basePath string) error {
 	basePath = filepath.Clean(basePath)
 
@@ -349,6 +349,7 @@ func archiveFile(tarWriter *tar.Writer, absPath, relPath string, info os.FileInf
 // For directories: creates destPath if needed and extracts contents.
 // For single files: destPath can be an existing directory (extract file there),
 // an existing file (overwrite), or a new file path (parent directory must exist).
+// Symlinks are silently skipped to avoid potential security issues.
 func extractTar(tarReader *tar.Reader, destPath string) error {
 	destPath = filepath.Clean(destPath)
 

--- a/file_transfer.go
+++ b/file_transfer.go
@@ -275,7 +275,7 @@ func handleUpload(stream *smux.Stream, destPath string) error {
 // For a single file, the archive contains one entry with the file's base name.
 // For a directory, the archive contains the directory and all its contents,
 // preserving the top-level directory name.
-// Symlinks pointing outside basePath are silently skipped.
+// Symlinks are silently skipped.
 func archivePath(tarWriter *tar.Writer, basePath string) error {
 	basePath = filepath.Clean(basePath)
 
@@ -294,8 +294,6 @@ func archivePath(tarWriter *tar.Writer, basePath string) error {
 		relPath = filepath.ToSlash(relPath)
 
 		switch {
-		case info.Mode()&os.ModeSymlink != 0:
-			return archiveSymlink(tarWriter, basePath, path, relPath)
 		case info.IsDir():
 			return archiveDir(tarWriter, relPath, info)
 		case info.Mode().IsRegular():
@@ -345,39 +343,8 @@ func archiveFile(tarWriter *tar.Writer, absPath, relPath string, info os.FileInf
 	return nil
 }
 
-func archiveSymlink(tarWriter *tar.Writer, basePath, absPath, relPath string) error {
-	linkTarget, err := os.Readlink(absPath)
-	if err != nil {
-		return fmt.Errorf("error reading symlink %s: %w", absPath, err)
-	}
-
-	// Validate the symlink target stays within the base path.
-	if err = validateSymlink(basePath, linkTarget, absPath); err != nil {
-		// Skip symlinks that escape the base directory.
-		return nil
-	}
-
-	// Convert absolute targets to relative paths for archive portability.
-	if filepath.IsAbs(linkTarget) {
-		linkTarget, err = filepath.Rel(filepath.Dir(absPath), linkTarget)
-		if err != nil {
-			// Skip if we can't compute a relative path.
-			return nil
-		}
-	}
-
-	header := &tar.Header{
-		Typeflag: tar.TypeSymlink,
-		Name:     relPath,
-		Linkname: filepath.ToSlash(linkTarget),
-	}
-
-	return tarWriter.WriteHeader(header)
-}
-
 // extractTar reads a tar archive and extracts its contents to destPath.
 // All paths are validated to prevent directory traversal attacks.
-// Symlinks with targets outside destPath are rejected.
 //
 // For directories: creates destPath if needed and extracts contents.
 // For single files: destPath can be an existing directory (extract file there),
@@ -472,11 +439,6 @@ func extractTarEntries(tarReader *tar.Reader, destPath, stripPrefix string) erro
 				return err
 			}
 
-		case tar.TypeSymlink:
-			if err = extractSymlink(destPath, root, relPath, header); err != nil {
-				return err
-			}
-
 		default:
 			// Skip unsupported entry types.
 			continue
@@ -521,25 +483,6 @@ func extractSingleFile(tarReader *tar.Reader, destPath string, header *tar.Heade
 	}()
 
 	return extractFile(root, filepath.Base(destPath), tarReader, header)
-}
-
-func extractSymlink(destPath string, root *os.Root, relPath string, header *tar.Header) error {
-	targetPath := filepath.Join(destPath, relPath)
-	if err := validateSymlink(destPath, header.Linkname, targetPath); err != nil {
-		return err
-	}
-
-	// Remove existing file/symlink at target path before creating new symlink.
-	_ = root.Remove(relPath)
-
-	// The parent components were created through the root, so they are genuine
-	// directories (not attacker-planted symlinks); creating the link does not follow
-	// any path component and the validated target stays within destPath.
-	if err := os.Symlink(header.Linkname, targetPath); err != nil {
-		return fmt.Errorf("error creating symlink %s: %w", relPath, err)
-	}
-
-	return nil
 }
 
 // mkdirAllRooted creates relPath and any missing parents relative to root. Each component is created
@@ -587,26 +530,4 @@ func validatePath(basePath, entryName string) (string, error) {
 	}
 
 	return cleanPath, nil
-}
-
-// validateSymlink checks that a symlink target resolves to a path
-// within the base directory.
-func validateSymlink(basePath, linkTarget, linkPath string) error {
-	cleanBase := filepath.Clean(basePath)
-
-	var resolved string
-
-	linkDir := filepath.Dir(linkPath)
-
-	if filepath.IsAbs(linkTarget) {
-		resolved = filepath.Clean(linkTarget)
-	} else {
-		resolved = filepath.Clean(filepath.Join(linkDir, linkTarget))
-	}
-
-	if resolved == cleanBase || strings.HasPrefix(resolved, cleanBase+string(filepath.Separator)) {
-		return nil
-	}
-
-	return fmt.Errorf("symlink %s target %s escapes base directory %s", linkPath, linkTarget, basePath)
 }

--- a/file_transfer_test.go
+++ b/file_transfer_test.go
@@ -25,8 +25,11 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
+	"slices"
+	"syscall"
 	"testing"
 	"time"
 
@@ -641,7 +644,7 @@ func TestFileTransfer_SymlinkWithinDirectory(t *testing.T) {
 		t.Fatalf("DownloadFile failed: %v", err)
 	}
 
-	// Verify the symlink was preserved.
+	// Verify the symlink was not preserved.
 	_, err := os.Readlink(filepath.Join(clientDir, "project", "link.go"))
 	if err == nil {
 		t.Fatalf("symlink found in downloaded directory: %v", err)
@@ -686,6 +689,215 @@ func TestFileTransfer_SymlinkEscapingSkipped(t *testing.T) {
 	// The escaping symlink should be skipped.
 	if _, err := os.Lstat(filepath.Join(clientDir, "project", "escape.txt")); err == nil {
 		t.Fatal("escaping symlink should have been skipped")
+	}
+}
+
+func TestArchivePath_OnlyRegularFilesAndDirectoriesAreArchived(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseDir := filepath.Join(tmpDir, "tree")
+
+	if err := os.MkdirAll(filepath.Join(baseDir, "sub"), 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(baseDir, "root.txt"), []byte("root"), 0644); err != nil {
+		t.Fatalf("failed to create root file: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(baseDir, "sub", "nested.txt"), []byte("nested"), 0644); err != nil {
+		t.Fatalf("failed to create nested file: %v", err)
+	}
+
+	// Symlink should be skipped by archivePath.
+	if err := os.Symlink(filepath.Join(baseDir, "root.txt"), filepath.Join(baseDir, "link.txt")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	// FIFO is a special file type and should be skipped by archivePath.
+	fifoPath := filepath.Join(baseDir, "pipe.fifo")
+	if err := syscall.Mkfifo(fifoPath, 0644); err != nil {
+		t.Fatalf("failed to create fifo: %v", err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := archivePath(tw, baseDir); err != nil {
+		t.Fatalf("archivePath failed: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer failed: %v", err)
+	}
+
+	tr := tar.NewReader(bytes.NewReader(buf.Bytes()))
+	var entryNames []string
+	var entryTypes []byte
+
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if err != nil {
+			t.Fatalf("error reading tar: %v", err)
+		}
+
+		entryNames = append(entryNames, hdr.Name)
+		entryTypes = append(entryTypes, hdr.Typeflag)
+	}
+
+	wantNames := []string{"tree/", "tree/root.txt", "tree/sub/", "tree/sub/nested.txt"}
+	for _, want := range wantNames {
+		if !slices.Contains(entryNames, want) {
+			t.Fatalf("expected tar entry %q, got entries: %v", want, entryNames)
+		}
+	}
+
+	if slices.Contains(entryNames, "tree/link.txt") {
+		t.Fatalf("symlink entry must not be archived, entries: %v", entryNames)
+	}
+
+	if slices.Contains(entryNames, "tree/pipe.fifo") {
+		t.Fatalf("special file entry must not be archived, entries: %v", entryNames)
+	}
+
+	for _, typeFlag := range entryTypes {
+		if typeFlag != tar.TypeDir && typeFlag != tar.TypeReg {
+			t.Fatalf("unexpected tar entry type %d found, only dir/file should be archived", typeFlag)
+		}
+	}
+}
+
+func TestArchivePath_SymlinkBasePathProducesNoEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	target := filepath.Join(tmpDir, "target.txt")
+	if err := os.WriteFile(target, []byte("content"), 0644); err != nil {
+		t.Fatalf("failed to create target file: %v", err)
+	}
+
+	link := filepath.Join(tmpDir, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	if err := archivePath(tw, link); err != nil {
+		t.Fatalf("archivePath failed: %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("closing tar writer failed: %v", err)
+	}
+
+	tr := tar.NewReader(bytes.NewReader(buf.Bytes()))
+	if _, err := tr.Next(); !errors.Is(err, io.EOF) {
+		t.Fatalf("expected no tar entries for symlink base path, got err: %v", err)
+	}
+}
+
+func TestExtractTar_OnlyDirectoryAndRegularFileEntriesAreMaterialized(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	writeHeader := func(hdr *tar.Header, body []byte) {
+		t.Helper()
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("failed to write tar header %q: %v", hdr.Name, err)
+		}
+
+		if len(body) > 0 {
+			if _, err := tw.Write(body); err != nil {
+				t.Fatalf("failed to write tar body for %q: %v", hdr.Name, err)
+			}
+		}
+	}
+
+	writeHeader(&tar.Header{Name: "safe/", Typeflag: tar.TypeDir, Mode: 0755}, nil)
+	writeHeader(&tar.Header{Name: "safe/file.txt", Typeflag: tar.TypeReg, Mode: 0644, Size: int64(len("ok"))}, []byte("ok"))
+
+	// The following entry types must never be materialized by extractTar.
+	writeHeader(&tar.Header{Name: "safe/link", Typeflag: tar.TypeSymlink, Linkname: "/etc/passwd", Mode: 0777}, nil)
+	writeHeader(&tar.Header{Name: "safe/hard", Typeflag: tar.TypeLink, Linkname: "safe/file.txt", Mode: 0644}, nil)
+	writeHeader(&tar.Header{Name: "safe/fifo", Typeflag: tar.TypeFifo, Mode: 0644}, nil)
+	writeHeader(&tar.Header{Name: "safe/chardev", Typeflag: tar.TypeChar, Mode: 0600, Devmajor: 1, Devminor: 3}, nil)
+	writeHeader(&tar.Header{Name: "safe/blockdev", Typeflag: tar.TypeBlock, Mode: 0600, Devmajor: 8, Devminor: 0}, nil)
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+
+	destDir := t.TempDir()
+	tr := tar.NewReader(bytes.NewReader(buf.Bytes()))
+	if err := extractTar(tr, destDir); err != nil {
+		t.Fatalf("extractTar failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(destDir, "safe")); err != nil {
+		t.Fatalf("expected directory to be extracted: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(destDir, "safe", "file.txt"))
+	if err != nil {
+		t.Fatalf("expected regular file to be extracted: %v", err)
+	}
+
+	if !bytes.Equal(got, []byte("ok")) {
+		t.Fatalf("regular file content mismatch: got %q", got)
+	}
+
+	notExpected := []string{
+		"safe/link",
+		"safe/hard",
+		"safe/fifo",
+		"safe/chardev",
+		"safe/blockdev",
+	}
+
+	for _, rel := range notExpected {
+		if _, err := os.Lstat(filepath.Join(destDir, rel)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("unexpected extracted special entry %q (err=%v)", rel, err)
+		}
+	}
+}
+
+func TestExtractTar_UnsupportedFirstEntryDoesNotCreateDestination(t *testing.T) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "top-link",
+		Typeflag: tar.TypeSymlink,
+		Linkname: "/etc/passwd",
+		Mode:     0777,
+	}); err != nil {
+		t.Fatalf("failed to write symlink header: %v", err)
+	}
+
+	if err := tw.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+
+	root := t.TempDir()
+	destPath := filepath.Join(root, "new-destination")
+
+	tr := tar.NewReader(bytes.NewReader(buf.Bytes()))
+	err := extractTar(tr, destPath)
+	if err == nil {
+		t.Fatal("expected error for unsupported first tar entry type, got nil")
+	}
+
+	var fileErr ErrFileTransfer
+	if !errors.As(err, &fileErr) {
+		t.Fatalf("expected ErrFileTransfer, got %T: %v", err, err)
+	}
+
+	if fileErr.Message != "Transfer of this file type is not supported" {
+		t.Fatalf("unexpected error message: %q", fileErr.Message)
+	}
+
+	if _, statErr := os.Stat(destPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("destination path should not be created on unsupported first entry, stat err: %v", statErr)
 	}
 }
 
@@ -839,234 +1051,5 @@ func TestFileTransfer_DownloadMultistreamDeadlock(t *testing.T) {
 	}
 	if !bytes.Equal(got, []byte("hello")) {
 		t.Fatalf("content mismatch: got %q", got)
-	}
-}
-
-// TestExtractTar_SymlinkTraversalEscape reproduces a path-traversal vulnerability
-// in extractTar: validateSymlink and validatePath are purely lexical, but
-// extractFile opens regular files with O_CREATE|O_WRONLY|O_TRUNC and no
-// O_NOFOLLOW. A crafted tar containing
-//
-//  1. a self-referential symlink   "d"    -> "."
-//  2. a traversing symlink         "evil" -> "d/../pwn"
-//  3. a regular file               "evil" with attacker-controlled contents
-//
-// passes every lexical check (filepath.Clean strips "d/.." textually so the
-// resolved target appears to be inside destPath), but on disk the kernel
-// follows the planted "d" symlink in step 3 and the truncate/write lands in
-// the *parent* directory of destPath.
-func TestExtractTar_SymlinkTraversalEscape(t *testing.T) {
-	// Use a dedicated parent so we can detect a file written one level above
-	// the extraction destination. t.TempDir() cleans this whole tree up.
-	parent := t.TempDir()
-	destPath := filepath.Join(parent, "dest")
-	if err := os.Mkdir(destPath, 0o755); err != nil {
-		t.Fatalf("failed to create destPath: %v", err)
-	}
-
-	// Sentinel that must NOT be overwritten. It lives in the parent dir,
-	// i.e. one level above destPath – the exact location the attack aims for.
-	sentinelPath := filepath.Join(parent, "pwn")
-	const originalContent = "original-untouched"
-	if err := os.WriteFile(sentinelPath, []byte(originalContent), 0o600); err != nil {
-		t.Fatalf("failed to seed sentinel file: %v", err)
-	}
-
-	// Build the malicious tar in memory.
-	var buf bytes.Buffer
-	tw := tar.NewWriter(&buf)
-
-	// 1. d -> "."  (self-reference; lexically resolves to destPath, allowed)
-	if err := tw.WriteHeader(&tar.Header{
-		Typeflag: tar.TypeSymlink,
-		Name:     "d",
-		Linkname: ".",
-		Mode:     0o777,
-	}); err != nil {
-		t.Fatalf("write header d: %v", err)
-	}
-
-	// 2. evil -> "d/../pwn"
-	//    validateSymlink computes Clean(destPath + "/" + "d/../pwn") = destPath/pwn,
-	//    which lexically lives inside destPath, so the check passes.
-	if err := tw.WriteHeader(&tar.Header{
-		Typeflag: tar.TypeSymlink,
-		Name:     "evil",
-		Linkname: "d/../pwn",
-		Mode:     0o777,
-	}); err != nil {
-		t.Fatalf("write header evil symlink: %v", err)
-	}
-
-	// 3. Regular file "evil". validatePath returns destPath/evil (allowed),
-	//    extractFile then OpenFile's it without O_NOFOLLOW, follows the planted
-	//    symlink, and the kernel resolves d/../pwn outside destPath.
-	pwned := []byte("PWNED-by-traversal")
-	if err := tw.WriteHeader(&tar.Header{
-		Typeflag: tar.TypeReg,
-		Name:     "evil",
-		Mode:     0o644,
-		Size:     int64(len(pwned)),
-	}); err != nil {
-		t.Fatalf("write header evil regular: %v", err)
-	}
-	if _, err := tw.Write(pwned); err != nil {
-		t.Fatalf("write evil body: %v", err)
-	}
-
-	if err := tw.Close(); err != nil {
-		t.Fatalf("close tar: %v", err)
-	}
-
-	// Drive the actual library entry point used on the device side.
-	tr := tar.NewReader(&buf)
-	if err := extractTar(tr, destPath); err != nil {
-		// An error here would actually be the *secure* outcome – the library
-		// should refuse the archive. We tolerate it and let the post-conditions
-		// below decide whether the attack succeeded.
-		t.Logf("extractTar returned error (acceptable if no escape occurred): %v", err)
-	}
-
-	// --- Post-conditions: the attack must NOT have escaped destPath. ---
-
-	// The sentinel file in the parent directory must still hold its original
-	// contents. If it now contains the attacker payload, the kernel followed
-	// the planted symlink and the write landed outside destPath.
-	got, err := os.ReadFile(sentinelPath)
-	if err != nil {
-		t.Fatalf("sentinel file unexpectedly missing: %v", err)
-	}
-	if string(got) != originalContent {
-		t.Fatalf(
-			"path traversal: file at %s (parent of destPath) was overwritten;\n"+
-				"  want %q\n  got  %q",
-			sentinelPath, originalContent, string(got),
-		)
-	}
-
-	// Nothing should ever have been created outside destPath as a side effect.
-	entries, err := os.ReadDir(parent)
-	if err != nil {
-		t.Fatalf("read parent dir: %v", err)
-	}
-	for _, e := range entries {
-		name := e.Name()
-		if name == "dest" || name == "pwn" {
-			continue
-		}
-		t.Errorf("unexpected entry created outside destPath: %s", name)
-	}
-}
-
-// TestExtractTar_IntermediateSymlinkTraversalEscape reproduces the incomplete-fix
-// bypass of GHSA-f9m7-vc86-p6jj / CVE-2026-55828. The v1.26.25 patch blocks the
-// final-symlink overwrite variant (covered by TestExtractTar_SymlinkTraversalEscape),
-// but validatePath/validateSymlink are still purely lexical while os.MkdirAll and
-// os.OpenFile follow symlink path *components* during real resolution.
-//
-// A crafted tar uses an intermediate symlink directory component:
-//
-//	d    -> .            (self-reference; lexically resolves to dest, allowed)
-//	evil -> d/..         (lexically Clean(dest/d/..) == dest, allowed)
-//	evil/outside-dir/    (MkdirAll follows evil -> ../outside-dir = parent of dest)
-//	evil/outside-dir/payload.txt (written outside dest)
-//
-// Chaining d before .. escapes multiple levels: "d/d/../.." escapes two levels.
-func TestExtractTar_IntermediateSymlinkTraversalEscape(t *testing.T) {
-	testCases := []struct {
-		name           string
-		linkTarget     string
-		escapedBaseDir func(root, parent string) string
-	}{
-		{
-			name:       "one parent level",
-			linkTarget: "d/..",
-			escapedBaseDir: func(root, parent string) string {
-				return parent
-			},
-		},
-		{
-			name:       "two parent levels",
-			linkTarget: "d/d/../..",
-			escapedBaseDir: func(root, parent string) string {
-				return root
-			},
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.name, func(t *testing.T) {
-			root := t.TempDir()
-			parent := filepath.Join(root, "parent")
-			destPath := filepath.Join(parent, "dest")
-			if err := os.MkdirAll(destPath, 0o755); err != nil {
-				t.Fatalf("failed to create destPath: %v", err)
-			}
-
-			escapedPayloadPath := filepath.Join(tt.escapedBaseDir(root, parent), "outside-dir", "payload.txt")
-			payload := []byte("PWNED-intermediate-symlink")
-
-			var buf bytes.Buffer
-			tw := tar.NewWriter(&buf)
-
-			if err := tw.WriteHeader(&tar.Header{
-				Typeflag: tar.TypeSymlink,
-				Name:     "d",
-				Linkname: ".",
-				Mode:     0o777,
-			}); err != nil {
-				t.Fatalf("write header d: %v", err)
-			}
-
-			if err := tw.WriteHeader(&tar.Header{
-				Typeflag: tar.TypeSymlink,
-				Name:     "evil",
-				Linkname: tt.linkTarget,
-				Mode:     0o777,
-			}); err != nil {
-				t.Fatalf("write header evil symlink: %v", err)
-			}
-
-			if err := tw.WriteHeader(&tar.Header{
-				Typeflag: tar.TypeDir,
-				Name:     "evil/outside-dir/",
-				Mode:     0o755,
-			}); err != nil {
-				t.Fatalf("write header outside-dir: %v", err)
-			}
-
-			if err := tw.WriteHeader(&tar.Header{
-				Typeflag: tar.TypeReg,
-				Name:     "evil/outside-dir/payload.txt",
-				Mode:     0o644,
-				Size:     int64(len(payload)),
-			}); err != nil {
-				t.Fatalf("write header payload: %v", err)
-			}
-			if _, err := tw.Write(payload); err != nil {
-				t.Fatalf("write payload body: %v", err)
-			}
-
-			if err := tw.Close(); err != nil {
-				t.Fatalf("close tar: %v", err)
-			}
-
-			err := extractTar(tar.NewReader(&buf), destPath)
-			if err == nil {
-				t.Errorf("expected extractTar to reject intermediate symlink traversal archive")
-			}
-
-			got, readErr := os.ReadFile(escapedPayloadPath)
-			if readErr == nil {
-				t.Fatalf(
-					"path traversal: payload was written outside destPath at %s; got %q",
-					escapedPayloadPath,
-					string(got),
-				)
-			}
-			if !os.IsNotExist(readErr) {
-				t.Fatalf("unexpected error checking escaped payload %s: %v", escapedPayloadPath, readErr)
-			}
-		})
 	}
 }

--- a/file_transfer_test.go
+++ b/file_transfer_test.go
@@ -642,13 +642,13 @@ func TestFileTransfer_SymlinkWithinDirectory(t *testing.T) {
 	}
 
 	// Verify the symlink was preserved.
-	linkTarget, err := os.Readlink(filepath.Join(clientDir, "project", "link.go"))
-	if err != nil {
-		t.Fatalf("symlink not found in downloaded directory: %v", err)
+	_, err := os.Readlink(filepath.Join(clientDir, "project", "link.go"))
+	if err == nil {
+		t.Fatalf("symlink found in downloaded directory: %v", err)
 	}
 
-	if linkTarget == "" {
-		t.Fatal("symlink target is empty")
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("unexpected error for symlink: %v", err)
 	}
 }
 
@@ -839,55 +839,6 @@ func TestFileTransfer_DownloadMultistreamDeadlock(t *testing.T) {
 	}
 	if !bytes.Equal(got, []byte("hello")) {
 		t.Fatalf("content mismatch: got %q", got)
-	}
-}
-
-func TestValidateSymlink(t *testing.T) {
-	base := "/tmp/extract"
-
-	tests := []struct {
-		name       string
-		linkTarget string
-		linkPath   string
-		wantErr    bool
-	}{
-		{
-			name:       "relative link within base",
-			linkTarget: "other.txt",
-			linkPath:   "/tmp/extract/dir/link.txt",
-			wantErr:    false,
-		},
-		{
-			name:       "relative link escaping base",
-			linkTarget: "../../etc/passwd",
-			linkPath:   "/tmp/extract/dir/link.txt",
-			wantErr:    true,
-		},
-		{
-			name:       "absolute link within base",
-			linkTarget: "/tmp/extract/other.txt",
-			linkPath:   "/tmp/extract/link.txt",
-			wantErr:    false,
-		},
-		{
-			name:       "absolute link escaping base",
-			linkTarget: "/etc/passwd",
-			linkPath:   "/tmp/extract/link.txt",
-			wantErr:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateSymlink(base, tt.linkTarget, tt.linkPath)
-			if tt.wantErr && err == nil {
-				t.Errorf("expected error for link %q -> %q", tt.linkPath, tt.linkTarget)
-			}
-
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected error for link %q -> %q: %v", tt.linkPath, tt.linkTarget, err)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
This pull request refactors the file transfer logic to improve security by completely skipping symlink handling during both archiving and extraction. Previously, symlinks were included if their targets were within the base directory, but now all symlinks are ignored to avoid potential security issues. Additionally, some code simplification and minor bug fixes are included.

**Security and Behavior Changes:**

* Symlinks are now silently skipped during both archiving and extraction, rather than being conditionally included based on their target. This change removes the previous logic for validating and handling symlinks, reducing attack surface. [[1]](diffhunk://#diff-85bc5c703d3908fa412dd44c3b91b440db7cae971c7dc43c746f2514e2fcd4c9L278-R278) [[2]](diffhunk://#diff-85bc5c703d3908fa412dd44c3b91b440db7cae971c7dc43c746f2514e2fcd4c9L297-L298) [[3]](diffhunk://#diff-85bc5c703d3908fa412dd44c3b91b440db7cae971c7dc43c746f2514e2fcd4c9L348-R352) [[4]](diffhunk://#diff-85bc5c703d3908fa412dd44c3b91b440db7cae971c7dc43c746f2514e2fcd4c9L475-L479) [[5]](diffhunk://#diff-85bc5c703d3908fa412dd44c3b91b440db7cae971c7dc43c746f2514e2fcd4c9L526-L544)

**Codebase Simplification:**

* The `archiveSymlink`, `extractSymlink`, and `validateSymlink` functions were removed, as symlink support is no longer needed. [[1]](diffhunk://#diff-85bc5c703d3908fa412dd44c3b91b440db7cae971c7dc43c746f2514e2fcd4c9L348-R352) [[2]](diffhunk://#diff-85bc5c703d3908fa412dd44c3b91b440db7cae971c7dc43c746f2514e2fcd4c9L526-L544) [[3]](diffhunk://#diff-85bc5c703d3908fa412dd44c3b91b440db7cae971c7dc43c746f2514e2fcd4c9L591-L612)

**Bug Fixes:**

* Fixed a bug in `mkdirAllRooted` by replacing `filepath.SplitList` with `strings.SplitSeq` to correctly split directory paths on the file separator.